### PR TITLE
Add Seasonal Referral System plugin skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# Wordpress-Refferal-System
+# Seasonal Referral System
+
+A seasonal affiliate and referral tracking plugin for WordPress. It supports seasonal campaigns, affiliate dashboards, REST API endpoints and commission tracking.
+
+## Setup
+1. Upload the `seasonal-referral-system` folder to your `wp-content/plugins` directory.
+2. Activate **Seasonal Referral System** from the WordPress Plugins screen.
+3. Adjust settings under **Seasonal Referrals → Settings**.
+
+## Shortcodes
+- `[srs_referral_link]` – outputs the logged-in user's referral URL.
+- `[srs_affiliate_dashboard]` – shows basic affiliate stats and referral link.
+
+## REST API
+Fetch affiliate information:
+```
+GET /wp-json/srs/v1/affiliate/<id>
+```
+Requires the `srs_manage` capability.
+
+## Recording Referrals
+Programmatically record a referral:
+```php
+use Seasonal\ReferralSystem\Referrals;
+
+// $affiliate_id is the ID from the srs_affiliates table.
+Referrals::record( $affiliate_id, 100.00, 'ORDER123' );
+```
+
+## Hooks
+- `srs_cookie_days` (option) – number of days to store referral cookie.
+
+## WooCommerce
+The plugin provides a helper to record referrals. WooCommerce orders can call `Referrals::record()` when an order completes to generate a referral entry.
+
+## License
+GPL-2.0-or-later

--- a/seasonal-referral-system/includes/Admin/AffiliatesTable.php
+++ b/seasonal-referral-system/includes/Admin/AffiliatesTable.php
@@ -1,0 +1,42 @@
+<?php
+namespace Seasonal\ReferralSystem\Admin;
+
+use WP_List_Table;
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class AffiliatesTable extends WP_List_Table {
+    public function get_columns(): array {
+        return [
+            'id'     => __( 'ID', 'seasonal-referral-system' ),
+            'user'   => __( 'User', 'seasonal-referral-system' ),
+            'code'   => __( 'Code', 'seasonal-referral-system' ),
+            'status' => __( 'Status', 'seasonal-referral-system' ),
+        ];
+    }
+
+    protected function get_sortable_columns(): array {
+        return [ 'id' => [ 'id', false ] ];
+    }
+
+    public function prepare_items(): void {
+        global $wpdb;
+        $table   = $wpdb->prefix . 'srs_affiliates';
+        $results = $wpdb->get_results( "SELECT id, user_id, code, status FROM {$table}", ARRAY_A );
+        $this->items = array_map(
+            function ( $row ) {
+                $user = get_user_by( 'id', (int) $row['user_id'] );
+                $row['user'] = $user ? $user->user_login : '';
+                return $row;
+            },
+            $results
+        );
+        $this->_column_headers = [ $this->get_columns(), [], $this->get_sortable_columns() ];
+    }
+
+    public function column_default( $item, $column_name ) {
+        return esc_html( $item[ $column_name ] ?? '' );
+    }
+}

--- a/seasonal-referral-system/includes/Admin/Menu.php
+++ b/seasonal-referral-system/includes/Admin/Menu.php
@@ -1,0 +1,73 @@
+<?php
+namespace Seasonal\ReferralSystem\Admin;
+
+use Seasonal\ReferralSystem\Admin\AffiliatesTable;
+use Seasonal\ReferralSystem\Admin\Settings;
+
+class Menu {
+    private static ?Menu $instance = null;
+
+    public static function instance(): Menu {
+        if ( self::$instance === null ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+    }
+
+    public function register_menu(): void {
+        add_menu_page(
+            __( 'Seasonal Referrals', 'seasonal-referral-system' ),
+            __( 'Seasonal Referrals', 'seasonal-referral-system' ),
+            'srs_manage',
+            'srs_affiliates',
+            [ $this, 'render_affiliates_page' ],
+            'dashicons-groups'
+        );
+        add_submenu_page(
+            'srs_affiliates',
+            __( 'Settings', 'seasonal-referral-system' ),
+            __( 'Settings', 'seasonal-referral-system' ),
+            'srs_manage',
+            'srs_settings',
+            [ $this, 'render_settings_page' ]
+        );
+    }
+
+    public function render_affiliates_page(): void {
+        if ( ! current_user_can( 'srs_manage' ) ) {
+            wp_die( esc_html__( 'You do not have permission.', 'seasonal-referral-system' ) );
+        }
+        $table = new AffiliatesTable();
+        $table->prepare_items();
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Affiliates', 'seasonal-referral-system' ); ?></h1>
+            <form method="post">
+                <?php $table->display(); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    public function render_settings_page(): void {
+        if ( ! current_user_can( 'srs_manage' ) ) {
+            wp_die( esc_html__( 'You do not have permission.', 'seasonal-referral-system' ) );
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Settings', 'seasonal-referral-system' ); ?></h1>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields( 'srs_settings' );
+                do_settings_sections( 'srs_settings' );
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+}

--- a/seasonal-referral-system/includes/Admin/Settings.php
+++ b/seasonal-referral-system/includes/Admin/Settings.php
@@ -1,0 +1,29 @@
+<?php
+namespace Seasonal\ReferralSystem\Admin;
+
+class Settings {
+    public static function register(): void {
+        add_action( 'admin_init', [ __CLASS__, 'settings' ] );
+    }
+
+    public static function settings(): void {
+        register_setting( 'srs_settings', 'srs_cookie_days', [
+            'type'              => 'integer',
+            'sanitize_callback' => 'absint',
+            'default'           => 30,
+        ] );
+
+        add_settings_section( 'srs_general', __( 'General', 'seasonal-referral-system' ), '__return_false', 'srs_settings' );
+
+        add_settings_field(
+            'srs_cookie_days',
+            __( 'Cookie days', 'seasonal-referral-system' ),
+            function (): void {
+                $val = (int) get_option( 'srs_cookie_days', 30 );
+                echo '<input type="number" name="srs_cookie_days" value="' . esc_attr( $val ) . '" />';
+            },
+            'srs_settings',
+            'srs_general'
+        );
+    }
+}

--- a/seasonal-referral-system/includes/AffiliateManager.php
+++ b/seasonal-referral-system/includes/AffiliateManager.php
@@ -1,0 +1,34 @@
+<?php
+namespace Seasonal\ReferralSystem;
+
+use wpdb;
+
+/**
+ * Basic affiliate utilities.
+ */
+class AffiliateManager {
+    public static function get_affiliate_code( int $user_id ): string {
+        global $wpdb;
+        $table = $wpdb->prefix . 'srs_affiliates';
+        $code  = $wpdb->get_var( $wpdb->prepare( "SELECT code FROM {$table} WHERE user_id = %d", $user_id ) );
+        if ( ! $code ) {
+            $code = self::generate_code( $user_id );
+            $wpdb->insert( $table, [
+                'user_id' => $user_id,
+                'code'    => $code,
+                'status'  => 'active',
+                'join_date' => current_time( 'mysql' ),
+            ] );
+        }
+        return $code;
+    }
+
+    public static function get_referral_url( int $user_id ): string {
+        $code = self::get_affiliate_code( $user_id );
+        return add_query_arg( 'ref', $code, home_url( '/' ) );
+    }
+
+    private static function generate_code( int $user_id ): string {
+        return 'u' . $user_id . wp_generate_password( 6, false );
+    }
+}

--- a/seasonal-referral-system/includes/Autoloader.php
+++ b/seasonal-referral-system/includes/Autoloader.php
@@ -1,0 +1,24 @@
+<?php
+namespace Seasonal\ReferralSystem;
+
+/**
+ * Simple PSR-4 autoloader for plugin classes.
+ */
+class Autoloader {
+    public static function register(): void {
+        spl_autoload_register( [ __CLASS__, 'autoload' ] );
+    }
+
+    private static function autoload( string $class ): void {
+        $prefix = __NAMESPACE__ . '\\';
+        if ( strncmp( $prefix, $class, strlen( $prefix ) ) !== 0 ) {
+            return;
+        }
+        $relative = substr( $class, strlen( $prefix ) );
+        $relative = str_replace( '\\', '/', $relative );
+        $file     = SRS_PATH . 'includes/' . $relative . '.php';
+        if ( file_exists( $file ) ) {
+            require_once $file;
+        }
+    }
+}

--- a/seasonal-referral-system/includes/Database/Installer.php
+++ b/seasonal-referral-system/includes/Database/Installer.php
@@ -1,0 +1,122 @@
+<?php
+namespace Seasonal\ReferralSystem\Database;
+
+use wpdb;
+
+/**
+ * Install and uninstall database tables.
+ */
+class Installer {
+    const VERSION = '1.0';
+
+    public static function activate(): void {
+        self::maybe_upgrade();
+        \Seasonal\ReferralSystem\Roles::add_caps();
+    }
+
+    public static function deactivate(): void {
+        // nothing for now
+    }
+
+    public static function uninstall(): void {
+        global $wpdb;
+        $tables = [
+            $wpdb->prefix . 'srs_affiliates',
+            $wpdb->prefix . 'srs_referrals',
+            $wpdb->prefix . 'srs_clicks',
+            $wpdb->prefix . 'srs_payouts',
+            $wpdb->prefix . 'srs_seasons',
+        ];
+        foreach ( $tables as $table ) {
+            $wpdb->query( "DROP TABLE IF EXISTS {$table}" );
+        }
+        delete_option( 'srs_db_version' );
+        \Seasonal\ReferralSystem\Roles::remove_caps();
+    }
+
+    private static function maybe_upgrade(): void {
+        $installed = get_option( 'srs_db_version' );
+        if ( self::VERSION === $installed ) {
+            return;
+        }
+        self::create_tables();
+        update_option( 'srs_db_version', self::VERSION );
+    }
+
+    private static function create_tables(): void {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $charset = $wpdb->get_charset_collate();
+
+        $affiliates = "CREATE TABLE {$wpdb->prefix}srs_affiliates (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            code VARCHAR(64) NOT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'active',
+            join_date DATETIME NOT NULL,
+            payment_method VARCHAR(100) DEFAULT '',
+            payout_address VARCHAR(200) DEFAULT '',
+            PRIMARY KEY  (id),
+            KEY user_id (user_id),
+            UNIQUE KEY code (code)
+        ) {$charset};";
+
+        $referrals = "CREATE TABLE {$wpdb->prefix}srs_referrals (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            affiliate_id BIGINT UNSIGNED NOT NULL,
+            season_id BIGINT UNSIGNED NOT NULL,
+            reference VARCHAR(191) DEFAULT '',
+            amount DECIMAL(18,8) NOT NULL DEFAULT 0,
+            commission DECIMAL(18,8) NOT NULL DEFAULT 0,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            KEY affiliate_id (affiliate_id),
+            KEY season_id (season_id)
+        ) {$charset};";
+
+        $clicks = "CREATE TABLE {$wpdb->prefix}srs_clicks (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            affiliate_id BIGINT UNSIGNED NOT NULL,
+            season_id BIGINT UNSIGNED NOT NULL,
+            ip_hash CHAR(32) NOT NULL,
+            user_agent_hash CHAR(32) NOT NULL,
+            landed_url TEXT,
+            referrer_url TEXT,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            KEY affiliate_id (affiliate_id)
+        ) {$charset};";
+
+        $payouts = "CREATE TABLE {$wpdb->prefix}srs_payouts (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            affiliate_id BIGINT UNSIGNED NOT NULL,
+            total_commission DECIMAL(18,8) NOT NULL DEFAULT 0,
+            fee DECIMAL(18,8) NOT NULL DEFAULT 0,
+            status VARCHAR(20) NOT NULL DEFAULT 'requested',
+            admin_note TEXT,
+            created_at DATETIME NOT NULL,
+            paid_at DATETIME NULL,
+            PRIMARY KEY (id),
+            KEY affiliate_id (affiliate_id)
+        ) {$charset};";
+
+        $seasons = "CREATE TABLE {$wpdb->prefix}srs_seasons (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            name VARCHAR(191) NOT NULL,
+            date_start DATETIME NOT NULL,
+            date_end DATETIME NOT NULL,
+            is_recurring TINYINT(1) NOT NULL DEFAULT 0,
+            active TINYINT(1) NOT NULL DEFAULT 1,
+            default_rate_type VARCHAR(10) NOT NULL DEFAULT 'percent',
+            default_rate_value DECIMAL(10,4) NOT NULL DEFAULT 0,
+            PRIMARY KEY (id)
+        ) {$charset};";
+
+        dbDelta( $affiliates );
+        dbDelta( $referrals );
+        dbDelta( $clicks );
+        dbDelta( $payouts );
+        dbDelta( $seasons );
+    }
+}

--- a/seasonal-referral-system/includes/Plugin.php
+++ b/seasonal-referral-system/includes/Plugin.php
@@ -1,0 +1,36 @@
+<?php
+namespace Seasonal\ReferralSystem;
+
+use Seasonal\ReferralSystem\Admin\Menu;
+use Seasonal\ReferralSystem\Admin\Settings;
+use Seasonal\ReferralSystem\Shortcodes\ReferralLink;
+use Seasonal\ReferralSystem\Shortcodes\AffiliateDashboard;
+use Seasonal\ReferralSystem\Rest\AffiliatesController;
+
+/**
+ * Main plugin bootstrap.
+ */
+class Plugin {
+    private static ?Plugin $instance = null;
+
+    public static function instance(): Plugin {
+        if ( self::$instance === null ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'init', [ $this, 'init' ] );
+        add_action( 'init', [ Tracking::class, 'maybe_set_cookie' ] );
+        Menu::instance();
+        Settings::register();
+        ReferralLink::register();
+        AffiliateDashboard::register();
+        AffiliatesController::register_routes();
+    }
+
+    public function init(): void {
+        load_plugin_textdomain( 'seasonal-referral-system', false, dirname( plugin_basename( SRS_FILE ) ) . '/languages/' );
+    }
+}

--- a/seasonal-referral-system/includes/Referrals.php
+++ b/seasonal-referral-system/includes/Referrals.php
@@ -1,0 +1,43 @@
+<?php
+namespace Seasonal\ReferralSystem;
+
+/**
+ * Helper to record referrals and commissions.
+ */
+class Referrals {
+    public static function record( int $affiliate_id, float $amount, string $reference = '', int $season_id = 0 ): int {
+        global $wpdb;
+        $season_id  = $season_id ?: self::current_season_id();
+        $rate       = self::get_commission_rate( $affiliate_id, $season_id );
+        $commission = $rate['type'] === 'percent' ? ( $amount * $rate['value'] / 100 ) : $rate['value'];
+        $wpdb->insert(
+            $wpdb->prefix . 'srs_referrals',
+            [
+                'affiliate_id' => $affiliate_id,
+                'season_id'    => $season_id,
+                'reference'    => $reference,
+                'amount'       => $amount,
+                'commission'   => $commission,
+                'status'       => 'pending',
+                'created_at'   => current_time( 'mysql' ),
+            ]
+        );
+        return (int) $wpdb->insert_id;
+    }
+
+    private static function current_season_id(): int {
+        global $wpdb;
+        $now = current_time( 'mysql' );
+        $id  = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$wpdb->prefix}srs_seasons WHERE active = 1 AND %s BETWEEN date_start AND date_end ORDER BY id DESC LIMIT 1", $now ) );
+        return (int) $id;
+    }
+
+    private static function get_commission_rate( int $affiliate_id, int $season_id ): array {
+        global $wpdb;
+        $season = $wpdb->get_row( $wpdb->prepare( "SELECT default_rate_type, default_rate_value FROM {$wpdb->prefix}srs_seasons WHERE id = %d", $season_id ), ARRAY_A );
+        if ( ! $season ) {
+            $season = [ 'default_rate_type' => 'percent', 'default_rate_value' => 0 ];
+        }
+        return [ 'type' => $season['default_rate_type'], 'value' => (float) $season['default_rate_value'] ];
+    }
+}

--- a/seasonal-referral-system/includes/Rest/AffiliatesController.php
+++ b/seasonal-referral-system/includes/Rest/AffiliatesController.php
@@ -1,0 +1,37 @@
+<?php
+namespace Seasonal\ReferralSystem\Rest;
+
+use WP_Error;
+use WP_REST_Request;
+
+class AffiliatesController {
+    const NAMESPACE = 'srs/v1';
+
+    public static function register_routes(): void {
+        add_action( 'rest_api_init', [ __CLASS__, 'routes' ] );
+    }
+
+    public static function routes(): void {
+        register_rest_route(
+            self::NAMESPACE,
+            '/affiliate/(?P<id>\d+)',
+            [
+                'methods'             => 'GET',
+                'callback'            => [ __CLASS__, 'get_affiliate' ],
+                'permission_callback' => function (): bool {
+                    return current_user_can( 'srs_manage' );
+                },
+            ]
+        );
+    }
+
+    public static function get_affiliate( WP_REST_Request $request ) {
+        global $wpdb;
+        $id   = (int) $request['id'];
+        $row  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}srs_affiliates WHERE id = %d", $id ), ARRAY_A );
+        if ( ! $row ) {
+            return new WP_Error( 'not_found', __( 'Affiliate not found', 'seasonal-referral-system' ), [ 'status' => 404 ] );
+        }
+        return rest_ensure_response( $row );
+    }
+}

--- a/seasonal-referral-system/includes/Roles.php
+++ b/seasonal-referral-system/includes/Roles.php
@@ -1,0 +1,28 @@
+<?php
+namespace Seasonal\ReferralSystem;
+
+class Roles {
+    public static function add_caps(): void {
+        $admin = get_role( 'administrator' );
+        if ( $admin ) {
+            $admin->add_cap( 'srs_manage' );
+            $admin->add_cap( 'srs_view_reports' );
+        }
+        $subscriber = get_role( 'subscriber' );
+        if ( $subscriber ) {
+            $subscriber->add_cap( 'srs_affiliate' );
+        }
+    }
+
+    public static function remove_caps(): void {
+        $roles = [ 'administrator', 'subscriber' ];
+        foreach ( $roles as $role_name ) {
+            $role = get_role( $role_name );
+            if ( $role ) {
+                $role->remove_cap( 'srs_manage' );
+                $role->remove_cap( 'srs_view_reports' );
+                $role->remove_cap( 'srs_affiliate' );
+            }
+        }
+    }
+}

--- a/seasonal-referral-system/includes/Shortcodes/AffiliateDashboard.php
+++ b/seasonal-referral-system/includes/Shortcodes/AffiliateDashboard.php
@@ -1,0 +1,39 @@
+<?php
+namespace Seasonal\ReferralSystem\Shortcodes;
+
+use Seasonal\ReferralSystem\AffiliateManager;
+
+class AffiliateDashboard {
+    public static function register(): void {
+        add_shortcode( 'srs_affiliate_dashboard', [ __CLASS__, 'render' ] );
+    }
+
+    public static function render(): string {
+        if ( ! is_user_logged_in() ) {
+            return '';
+        }
+        global $wpdb;
+        $user_id      = get_current_user_id();
+        $code         = AffiliateManager::get_affiliate_code( $user_id );
+        $url          = AffiliateManager::get_referral_url( $user_id );
+        $aff_table    = $wpdb->prefix . 'srs_affiliates';
+        $affiliate_id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$aff_table} WHERE user_id = %d", $user_id ) );
+        $clicks       = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}srs_clicks WHERE affiliate_id = %d", $affiliate_id ) );
+        $referrals    = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}srs_referrals WHERE affiliate_id = %d", $affiliate_id ) );
+        $commission   = (float) $wpdb->get_var( $wpdb->prepare( "SELECT SUM(commission) FROM {$wpdb->prefix}srs_referrals WHERE affiliate_id = %d AND status = 'approved'", $affiliate_id ) );
+
+        ob_start();
+        ?>
+        <div class="srs-dashboard">
+            <p><?php echo esc_html__( 'Your affiliate code:', 'seasonal-referral-system' ) . ' ' . esc_html( $code ); ?></p>
+            <p><?php echo esc_html__( 'Referral URL:', 'seasonal-referral-system' ) . ' ' . esc_url( $url ); ?></p>
+            <ul>
+                <li><?php echo esc_html__( 'Clicks:', 'seasonal-referral-system' ) . ' ' . esc_html( $clicks ); ?></li>
+                <li><?php echo esc_html__( 'Referrals:', 'seasonal-referral-system' ) . ' ' . esc_html( $referrals ); ?></li>
+                <li><?php echo esc_html__( 'Commission:', 'seasonal-referral-system' ) . ' ' . esc_html( number_format_i18n( $commission, 2 ) ); ?></li>
+            </ul>
+        </div>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/seasonal-referral-system/includes/Shortcodes/ReferralLink.php
+++ b/seasonal-referral-system/includes/Shortcodes/ReferralLink.php
@@ -1,0 +1,18 @@
+<?php
+namespace Seasonal\ReferralSystem\Shortcodes;
+
+use Seasonal\ReferralSystem\AffiliateManager;
+
+class ReferralLink {
+    public static function register(): void {
+        add_shortcode( 'srs_referral_link', [ __CLASS__, 'render' ] );
+    }
+
+    public static function render(): string {
+        if ( ! is_user_logged_in() ) {
+            return '';
+        }
+        $url = AffiliateManager::get_referral_url( get_current_user_id() );
+        return esc_url( $url );
+    }
+}

--- a/seasonal-referral-system/includes/Tracking.php
+++ b/seasonal-referral-system/includes/Tracking.php
@@ -1,0 +1,21 @@
+<?php
+namespace Seasonal\ReferralSystem;
+
+/**
+ * Handle referral tracking via query parameter and cookie.
+ */
+class Tracking {
+    const COOKIE = 'srs_ref';
+
+    public static function maybe_set_cookie(): void {
+        if ( isset( $_GET['ref'] ) ) {
+            $code = sanitize_text_field( wp_unslash( $_GET['ref'] ) );
+            $days = (int) get_option( 'srs_cookie_days', 30 );
+            setcookie( self::COOKIE, $code, time() + DAY_IN_SECONDS * $days, COOKIEPATH, COOKIE_DOMAIN );
+        }
+    }
+
+    public static function get_code_from_cookie(): ?string {
+        return isset( $_COOKIE[ self::COOKIE ] ) ? sanitize_text_field( wp_unslash( $_COOKIE[ self::COOKIE ] ) ) : null;
+    }
+}

--- a/seasonal-referral-system/seasonal-referral-system.php
+++ b/seasonal-referral-system/seasonal-referral-system.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plugin Name: Seasonal Referral System
+ * Plugin URI:  https://example.com
+ * Description: Seasonal affiliate and referral tracking system with seasonal campaigns and payouts.
+ * Version:     0.1.0
+ * Author:      Example Author
+ * Author URI:  https://example.com
+ * Text Domain: seasonal-referral-system
+ * Requires PHP: 8.1
+ * Requires at least: 6.6
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'SRS_FILE', __FILE__ );
+define( 'SRS_PATH', plugin_dir_path( __FILE__ ) );
+require_once SRS_PATH . 'includes/Autoloader.php';
+Seasonal\ReferralSystem\Autoloader::register();
+
+register_activation_hook( __FILE__, [ Seasonal\ReferralSystem\Database\Installer::class, 'activate' ] );
+register_deactivation_hook( __FILE__, [ Seasonal\ReferralSystem\Database\Installer::class, 'deactivate' ] );
+register_uninstall_hook( __FILE__, [ Seasonal\ReferralSystem\Database\Installer::class, 'uninstall' ] );
+
+Seasonal\ReferralSystem\Plugin::instance();

--- a/seasonal-referral-system/templates/emails/new-affiliate.php
+++ b/seasonal-referral-system/templates/emails/new-affiliate.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Email template for new affiliate notification.
+ *
+ * @package SeasonalReferralSystem
+ */
+?>
+<p><?php echo esc_html( sprintf( __( 'Welcome to the %s affiliate program!', 'seasonal-referral-system' ), get_bloginfo( 'name' ) ) ); ?></p>

--- a/tests/test-referrals.php
+++ b/tests/test-referrals.php
@@ -1,0 +1,12 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Seasonal\ReferralSystem\Referrals;
+
+/**
+ * Basic tests for referral calculations.
+ */
+class ReferralsTest extends TestCase {
+    public function test_commission_calculation(): void {
+        $this->assertTrue( method_exists( Referrals::class, 'record' ) );
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce Seasonal Referral System plugin with custom tables, roles, tracking cookie, and shortcodes for referral link and affiliate dashboard
- Add REST endpoint for fetching affiliate data and admin pages including settings and affiliate list using WP_List_Table
- Provide helper for programmatic referral recording and sample email template

## Testing
- `php -l seasonal-referral-system/seasonal-referral-system.php`
- `find seasonal-referral-system -name '*.php' -print0 | xargs -0 -n1 php -l`
- `phpcs --standard=WordPress seasonal-referral-system/seasonal-referral-system.php` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec0088c9c83308f86d9c4339b0c1f